### PR TITLE
Misc Cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,7 @@ name = "jaz"
 version = "0.0.2"
 dependencies = [
  "git2",
+ "once_cell",
  "regex",
 ]
 
@@ -157,6 +158,12 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "openssl-probe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [
 
 [dependencies]
 git2 = "0.13" 
+once_cell = "1.8.0"
 regex = "1.5.4"
 
 [package.metadata.arch]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,16 @@
 use git2::{ObjectType, OdbObject, Repository};
 use once_cell::sync::Lazy;
 use regex::bytes::RegexSet;
+use std::ffi::OsString;
 
 const INFO: &str = "\x1b[32m[INFO]\x1b[0m";
 const CRITICAL: &str = "\x1b[31m[CRITICAL]\x1b[0m";
 
 fn main() {
     // Get path to git repo via command line args or assume current directory
-    let repo_root: String = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
+    let repo_root: OsString = std::env::args_os()
+        .nth(1)
+        .unwrap_or_else(|| OsString::from("."));
 
     // Open git repo
     let repo = Repository::open(&repo_root).expect("Couldn't open repository");

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ fn main() {
     let repo_root: String = std::env::args().nth(1).unwrap_or_else(|| ".".to_string());
 
     // Open git repo
-    let repo = Repository::open(repo_root.as_str()).expect("Couldn't open repository");
+    let repo = Repository::open(&repo_root).expect("Couldn't open repository");
 
     println!(
         "{} {} state={:?}",
@@ -47,12 +47,7 @@ fn scan_object(obj: &Object, oid: &Oid) {
         // Check if the blob contains secrets
         if let Some(secrets_found) = find_secrets(blob_str) {
             for bad in secrets_found {
-                println!(
-                    "{} object {} has a secret of type `{}`",
-                    CRITICAL,
-                    oid,
-                    bad
-                );
+                println!("{} object {} has a secret of type `{}`", CRITICAL, oid, bad);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,18 +2,8 @@ use git2::{Object, ObjectType, Oid, Repository};
 use regex::Regex;
 use std::collections::HashMap;
 
-// Macros for logging
-macro_rules! info {
-    () => {
-        format!("{}[INFO]{}", "\x1B[32m", "\x1B[0m")
-    };
-}
-
-macro_rules! critical {
-    () => {
-        format!("{}[CRITICAL]{}", "\x1B[31m", "\x1B[0m")
-    };
-}
+const INFO: &str = "\x1b[32m[INFO]\x1b[0m";
+const CRITICAL: &str = "\x1b[31m[CRITICAL]\x1b[0m";
 
 fn main() {
     // Get path to git repo via command line args or assume current directory
@@ -24,7 +14,7 @@ fn main() {
 
     println!(
         "{} {} state={:?}",
-        info!(),
+        INFO,
         repo.path().display(),
         repo.state()
     );
@@ -59,7 +49,7 @@ fn scan_object(obj: &Object, oid: &Oid) {
             for bad in secrets_found {
                 println!(
                     "{} object {} has a secret of type `{}`",
-                    critical!(),
+                    CRITICAL,
                     oid,
                     bad
                 );

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
-use git2::{Object, ObjectType, Oid, Repository};
-use regex::Regex;
-use std::collections::HashMap;
+use git2::{ObjectType, OdbObject, Repository};
+use once_cell::sync::Lazy;
+use regex::bytes::RegexSet;
 
 const INFO: &str = "\x1b[32m[INFO]\x1b[0m";
 const CRITICAL: &str = "\x1b[31m[CRITICAL]\x1b[0m";
@@ -24,11 +24,11 @@ fn main() {
     let odb = repo.odb().unwrap();
 
     // Loop through objects in db
-    odb.foreach(|oid| {
-        let obj = repo.revparse_single(&oid.to_string()).unwrap();
+    odb.foreach(|&oid| {
+        let obj = odb.read(oid).unwrap();
 
         // Look for secrets in the object
-        scan_object(&obj, oid);
+        scan_object(&obj);
 
         // Return true because the closure has to return a boolean
         true
@@ -36,26 +36,26 @@ fn main() {
     .unwrap();
 }
 
-fn scan_object(obj: &Object, oid: &Oid) {
-    if let Some(ObjectType::Blob) = obj.kind() {
-        let blob_str = match std::str::from_utf8(obj.as_blob().unwrap().content()) {
-            Ok(x) => x,
-            Err(_) => return,
-        };
-        // println!("{}",blob_str);
-
-        // Check if the blob contains secrets
-        if let Some(secrets_found) = find_secrets(blob_str) {
-            for bad in secrets_found {
-                println!("{} object {} has a secret of type `{}`", CRITICAL, oid, bad);
-            }
+fn scan_object(obj: &OdbObject) {
+    if obj.kind() != ObjectType::Blob {
+        return;
+    }
+    // Check if the blob contains secrets
+    if let Some(secrets_found) = find_secrets(obj.data()) {
+        for bad in secrets_found {
+            println!(
+                "{} object {} has a secret of type `{}`",
+                CRITICAL,
+                obj.id(),
+                bad
+            );
         }
     }
 }
 
 // find_secrets : if secrets are found in blob then they are returned as a vector, otherwise return None
-fn find_secrets(blob: &str) -> Option<Vec<String>> {
-    let rules = HashMap::from([
+fn find_secrets(blob: &[u8]) -> Option<Vec<&'static str>> {
+    const RULES: &[(&str, &str)] = &[
         ("Slack Token", "(xox[p|b|o|a]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})"),
         ("RSA private key", "-----BEGIN RSA PRIVATE KEY-----"),
         ("SSH (OPENSSH) private key", "-----BEGIN OPENSSH PRIVATE KEY-----"),
@@ -74,20 +74,15 @@ fn find_secrets(blob: &str) -> Option<Vec<String>> {
         ("Google (GCP) Service-account", "\"type\": \"service_account\""),
         ("Twilio API Key", "SK[a-z0-9]{32}"),
         ("Password in URL", "[a-zA-Z]{3,10}://[^/\\s:@]{3,20}:[^/\\s:@]{3,20}@.{1,100}[\"'\\s]"),
-    ]);
+    ];
+    static REGEX_SET: Lazy<RegexSet> = Lazy::new(|| {
+        RegexSet::new(RULES.iter().map(|&(_, regex)| regex)).expect("All regexes should be valid")
+    });
 
-    let mut secrets_found = vec![];
-    for (key, val) in rules {
-        // Use regex from rules file to match against blob
-        let re = Regex::new(val).unwrap();
-        if re.is_match(blob) {
-            secrets_found.push(key.to_string());
-        }
+    let matches = REGEX_SET.matches(blob);
+    if !matches.matched_any() {
+        return None;
     }
 
-    if !secrets_found.is_empty() {
-        // Return bad commits if there are any
-        return Some(secrets_found);
-    }
-    None
+    Some(matches.iter().map(|i| RULES[i].0).collect())
 }


### PR DESCRIPTION
* Change info/critical macros to be constant strings
* Use `odb.read()` to read the objects directly rather than re-parsing
* Use byte based regex, to avoid having to do utf8 validation
* Use a `RegexSet`, which allows checking for multiple regexes in one scan
* Use `Lazy` from once_cell to cache regex compilation
* Use `OsString` argument to allow non-Unicode paths